### PR TITLE
More gluster: ssl support, logging, local build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ TAG=$1
 build() {
     docker plugin rm -f ximoneighteen/$1 || true
     docker rmi -f rootfsimage || true
-    docker build -t rootfsimage $1
+    docker build -t rootfsimage -f $1/Dockerfile .
     id=$(docker create rootfsimage true) # id was cd851ce43a403 when the image was created
     rm -rf build/rootfs
     mkdir -p build/rootfs

--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -12,4 +12,5 @@ RUN /usr/local/go/bin/go get github.com/ximon18/docker-volume-plugins/glusterfs-
     yum autoremove -q -y && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
-    rm /var/log/lastlog /var/log/tallylog
+    rm /var/log/lastlog /var/log/tallylog && \
+    mkdir /var/lib/glusterd

--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -5,11 +5,14 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 RUN yum install -y oracle-gluster-release-el7 && \
-    yum install -y glusterfs glusterfs-fuse attr && \
+    yum install -y glusterfs glusterfs-fuse attr rsyslog && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
     rm /var/log/lastlog /var/log/tallylog && \
-    mkdir /var/lib/glusterd
+    mkdir -p /var/lib/glusterd /etc/glusterfs && \
+    touch /etc/glusterfs/logger.conf
+
+COPY glusterfs-volume-plugin/rsyslog.conf /etc/rsyslog.conf
 
 FROM base as dev
 

--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -1,16 +1,27 @@
-FROM oraclelinux:7-slim
-ENV TINI_VERSION v0.18.0
+FROM oraclelinux:7-slim as base
+ARG TINI_VERSION="v0.18.0"
+
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
-RUN yum install -q -y oracle-gluster-release-el7 && \
-    yum install -q -y git glusterfs glusterfs-fuse attr && \
-    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
-RUN /usr/local/go/bin/go get github.com/ximon18/docker-volume-plugins/glusterfs-volume-plugin && \
-    mv $HOME/go/bin/glusterfs-volume-plugin / && \
-    rm -rf $HOME/go /usr/local/go && \
-    yum remove -q -y git && \
-    yum autoremove -q -y && \
+
+RUN yum install -y oracle-gluster-release-el7 && \
+    yum install -y glusterfs glusterfs-fuse attr && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
     rm /var/log/lastlog /var/log/tallylog && \
     mkdir /var/lib/glusterd
+
+FROM base as dev
+
+RUN curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf - && \
+    yum install -y git
+
+COPY glusterfs-volume-plugin/ /root/go/src/github.com/ximon18/docker-volume-plugins/glusterfs-volume-plugin
+COPY mounted-volume/ /root/go/src/github.com/ximon18/docker-volume-plugins/mounted-volume
+
+RUN cd /root/go/src/github.com/ximon18/docker-volume-plugins/glusterfs-volume-plugin && \
+    /usr/local/go/bin/go get
+
+FROM base
+
+COPY --from=dev /root/go/bin/glusterfs-volume-plugin /

--- a/glusterfs-volume-plugin/README.md
+++ b/glusterfs-volume-plugin/README.md
@@ -76,3 +76,9 @@ This is an example of mounting and testing a store outside the swarm.  It is ass
     docker plugin enable trajano/glusterfs-volume-plugin
     docker volume create -d trajano/glusterfs-volume-plugin --opt servers=store1 trajano
     docker run -it -v trajano:/mnt alpine
+
+## SSL support
+
+Host path `/etc/ssl` is made available to gluster clients so to configure SSL you should follow steps from GlusterFS documentation.
+
+To secure management channel (server to server communication), set `SECURE_MANAGEMENT` to non empty value, eg.: `docker plugin glusterfs set SECURE_MANAGEMENT=yes`.

--- a/glusterfs-volume-plugin/config.json
+++ b/glusterfs-volume-plugin/config.json
@@ -13,6 +13,13 @@
                 "value"
             ],
             "value": ""
+        },
+        {
+            "name": "SECURE_MANAGEMENT",
+            "settable": [
+                "value"
+            ],
+            "value": ""
         }
     ],
     "network": {
@@ -34,5 +41,15 @@
                 "path": "/dev/fuse"
             }
         ]
-    }
+    },
+    "mounts": [
+        {
+            "name": "ssl",
+            "source": "/etc/ssl",
+            "description": "",
+            "destination": "/etc/ssl",
+            "type": "bind",
+            "options": ["readonly", "shared", "rbind"]
+        }
+    ]
 }

--- a/glusterfs-volume-plugin/main.go
+++ b/glusterfs-volume-plugin/main.go
@@ -83,6 +83,15 @@ func buildDriver() *gfsDriver {
 		Driver:  *mountedvolume.NewDriver("glusterfs", true, "gfs", "local"),
 		servers: servers,
 	}
+
+	if os.Getenv("SECURE_MANAGEMENT") != "" {
+		file, err := os.Create("/var/lib/glusterd/secure-access")
+        if err != nil {
+            log.Fatal("Could not create secure-access file: "+err.Error())
+        }
+        defer file.Close()
+	}
+
 	d.Init(d)
 	return d
 }

--- a/glusterfs-volume-plugin/main.go
+++ b/glusterfs-volume-plugin/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/docker/go-plugins-helpers/volume"
@@ -54,6 +55,8 @@ func (p *gfsDriver) MountOptions(req *volume.CreateRequest) []string {
 		args = strings.Split(glusteropts, " ")
 	}
 
+	args = append(args, "--logger=syslog")
+
 	return args
 }
 
@@ -96,8 +99,13 @@ func buildDriver() *gfsDriver {
 	return d
 }
 
+func spawnSyslog() {
+	cmd := exec.Command("rsyslogd", "-n")
+	cmd.Start()
+}
+
 func main() {
-	log.SetFlags(0)
+	spawnSyslog()
 	d := buildDriver()
 	defer d.Close()
 	d.ServeUnix()

--- a/glusterfs-volume-plugin/rsyslog.conf
+++ b/glusterfs-volume-plugin/rsyslog.conf
@@ -1,0 +1,16 @@
+$ModLoad imuxsock
+$WorkDirectory /var/lib/rsyslog
+
+template(name="DockerFormat" type="list") {
+    constant(value="glusterfs-volume-plugin: ")
+    property(name="syslogtag")
+    property(name="msg" spifno1stsp="on" )
+    property(name="msg" droplastlf="on" )
+    constant(value="\n")
+}
+
+$ActionFileDefaultTemplate DockerFormat
+$SystemLogSocketName /dev/log
+$LogRSyslogStatusMessages off
+
+*.*                                                 /proc/1/fd/1


### PR DESCRIPTION
I've added SSL support (clients and/or secure management channel),
plugin can now be built with local sources and not ones fetched from github,
and at least logging for gluster clients to see whats happening inside :)

logs are prefixed and visible on host like:
```
Oct 01 12:06:50 snipsnip dockerd[954]: time="2020-10-01T12:06:50+02:00" level=info msg="glusterfs-volume-plugin:
var-lib-docker-volumes-db0c4032bfb1f9dc1f284987f6b20be9a711157a27a29bfcbcf0fd7afdd65b7a[87]: [fuse-bridge.c:6088:fuse_thread_proc] 0-f
use: initating unmount of /var/lib/docker-volumes/db0c4032bfb1f9dc1f284987f6b20be9a711157a27a29bfcbcf0fd7afdd65b7a" plugin=08e3c146cd5
b7328cf1f12a9713b616d1b2a56568544542c9616ab7c3b801fe9
Oct 01 12:06:50 snipsnip dockerd[954]: time="2020-10-01T12:06:50+02:00" level=info msg="glusterfs-volume-plugin:
var-lib-docker-volumes-db0c4032bfb1f9dc1f284987f6b20be9a711157a27a29bfcbcf0fd7afdd65b7a[87]: [glusterfsd.c:1570:cleanup_and_exit] (-->
/lib64/libpthread.so.0(+0x7ea5) [0x7f09d244aea5] -->glusterfs(glusterfs_sigwaiter+0xe5) [0x5589c33a61f5] -->glusterfs(cleanup_and_exit
+0x6b) [0x5589c33a605b] ) 0-: received signum (15), shutting down" plugin=08e3c146cd5b7328cf1f12a9713b616d1b2a56568544542c9616ab7c3b80
1fe9
```